### PR TITLE
Resolved notice date > 7days

### DIFF
--- a/src/components/home/notice.js
+++ b/src/components/home/notice.js
@@ -6,7 +6,7 @@ const Notice = props => {
   const newtime = new Date().getTime()
 
   let d = Math.round((newtime - props.time) / 3600000)
-  if (d > 48) {
+  if (d > 168) {
     d = new Date(props.time).toLocaleDateString()
   } else if (d > 24) {
     d = `${Math.round(d / 24)} days ago`


### PR DESCRIPTION
This pull request resolves notice dates to appear in dd/mm/yyyy format only after 7 days of opening. For days >1 & < 7 "X days ago" is the format.

Maintainers please merge.